### PR TITLE
Improve miner handshake reliability

### DIFF
--- a/miner.lua
+++ b/miner.lua
@@ -32,7 +32,8 @@ local function sendEvent(event, extra)
   if extra then
     for k,v in pairs(extra) do payload[k] = v end
   end
-  rednet.send(0, textutils.serialize(payload))
+  -- send as a broadcast so the controller can always hear us
+  rednet.broadcast(textutils.serialize(payload))
 end
 
 local function saveState(state)


### PR DESCRIPTION
## Summary
- fix miner handshake broadcast logic so new turtles are reliably detected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c079ca9348320908d471f1b5e7aa4