### PR TITLE
Implement new controller menu and start mining protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,22 @@ This repository contains two programs:
 
 * **controller.lua** – run on a computer. It coordinates multiple mining turtles over `rednet`.
 * **miner.lua** – run on a turtle. It receives jobs from the controller and mines.
+Each job corresponds to the centre of a 16×16 chunk, producing a 15×15 shaft.
 
 ## Basic usage
-1. Place a modem on both the computer and each turtle and set unique labels for the turtles.
+1. Attach a modem to the computer and each turtle and set unique labels for every turtle.
 2. Run `controller.lua` on the computer and `miner.lua` on each turtle.
-3. Turtles automatically receive jobs once they connect.
+3. Use the controller's menu (↑/↓ and Enter) to start turtles and begin mining.
 
-### Controller controls
-- Press **ESC** to enter command mode and type commands shown at the bottom of the screen.
-- Use the arrow keys to select a turtle. Press **Enter** to open the per‑turtle menu (Ping/Resume). Press **ESC** again to return to the command prompt.
+### Controller Menu
+1. Change Mining Start Depth
+2. Start Turtle
+3. Start Mining
+4. Pause Mining
+5. Resume Mining
+6. View Status
+
+Press **Backspace** to return from sub‑menus.
 
 ### Turtle display
 Each turtle now shows its current GPS coordinates and chunk position on the first line of its display.


### PR DESCRIPTION
## Summary
- overhaul controller menu with 6-option interface and back navigation
- add start depth setting and fixed 16×16 grid
- implement start_mining handshake with turtles
- update miner to wait for start_mining before beginning
- refresh README instructions

## Testing
- `luacheck` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d494164e88320a1fe1e0b1a59528e