### PR TITLE
Maintain full fuel stack for quarry turtle

### DIFF
--- a/quarry.lua
+++ b/quarry.lua
@@ -41,6 +41,39 @@ local function dropNotFuel()
  turtle.select(1)
 end --function
 
+local function fillFuelStack()
+ local slot
+ for i=1,16 do
+  turtle.select(i)
+  if turtle.getItemCount(i) > 0 and turtle.refuel(0) then
+   slot = i
+   break
+  end --if
+ end --for
+ if not slot then
+  turtle.select(1)
+  if not turtle.suck(64) then
+   turtle.select(1)
+   return false
+  end --if
+  if not turtle.refuel(0) then
+   turtle.drop()
+   turtle.select(1)
+   return false
+  end --if
+  slot = 1
+ end --if
+ turtle.select(slot)
+ while turtle.getItemCount(slot) < 64 do
+  if not turtle.suck(64 - turtle.getItemCount(slot)) then
+   turtle.select(1)
+   return false
+  end --if
+ end --while
+ turtle.select(1)
+ return true
+end --function
+
 local function refuelFromChest()
  for x=1,16 do
   turtle.select(x)
@@ -103,6 +136,9 @@ while not done and not dig.isStuck() do
    sleep(1)
   end --if
  end --while
+ while not fillFuelStack() do
+  sleep(1)
+ end --while
  flex.send("Thanks!",colors.lime)
  dig.goto(loc)
 end --if
@@ -147,10 +183,13 @@ end --if
  end --if/else
  
  if turtle.getItemCount(15) > 0 then
-  loc = dig.location()
+ loc = dig.location()
  dig.goto(0,0,0,180)
  dropNotFuel()
  refuelFromChest()
+ while not fillFuelStack() do
+  sleep(1)
+ end --while
  dig.goto(loc)
 end --if
  


### PR DESCRIPTION
## Summary
- add `fillFuelStack` to load fuel up to a full stack
- use `fillFuelStack` when refueling and unloading to keep 64 fuel items on hand
- avoid redundant topping-off by only refueling from the chest when already at base

## Testing
- `luac -p quarry.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e5a8d27e083208ff5319c6fe331a2