### PR TITLE
Add global return handling and chest fail-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@ quarry 16 16 30   -- dig a 16×16 quarry 30 blocks deep
 
 Run `receive` on a computer with a modem attached to monitor messages sent with `flex.lua`'s `send` function.
 
+## Global Control
+Turtles running `quarry.lua` listen for a Rednet broadcast of the string `RETURN`. Broadcasting `RETURN` causes every turtle to navigate home, unload, refuel, and then automatically resume mining. If the chest at home is missing, the turtle waits and reports an error until the chest is restored.
+
 These scripts are intended for experimentation. Adjust the code and parameters to suit your own mining setup.


### PR DESCRIPTION
## Summary
- Turtles now open Rednet, listen for a global RETURN broadcast, and use a run flag for crash recovery
- Added chest detection with automatic pausing if the home chest is missing and a unified return-to-base routine
- Updated README with instructions for broadcasting RETURN to all turtles

## Testing
- `luac -p quarry.lua flex.lua dig.lua receive.lua stairs.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f836a320c8320a9b61b7fc2c8b8bf